### PR TITLE
fix bug in pretreatment att

### DIFF
--- a/R/att_dr.R
+++ b/R/att_dr.R
@@ -68,9 +68,9 @@ att_dr <- function(did_preprocessed) {
   }
 
   # Compute Doubly Robust Triple Difference Estimator
-  dr_att_inf_func_3 <- compute_did(data, condition_subgroup = 3, pscores, reg_adjust, xformula, est_method) # S=2, L=A
-  dr_att_inf_func_2 <- compute_did(data, condition_subgroup = 2, pscores, reg_adjust, xformula, est_method) # S=\infty, L=B
-  dr_att_inf_func_1 <- compute_did(data, condition_subgroup = 1, pscores, reg_adjust, xformula, est_method) # S=\infty, L=A
+  dr_att_inf_func_3 <- compute_did(data, condition_subgroup = 3, pscores = pscores, reg_adjustment = reg_adjust, xformula = xformula, est_method = est_method) # S=g, Q=1 vs. S=g, Q=0
+  dr_att_inf_func_2 <- compute_did(data, condition_subgroup = 2, pscores = pscores, reg_adjustment = reg_adjust, xformula = xformula, est_method = est_method) # S=g, Q=1 vs. S=\infty, Q=1
+  dr_att_inf_func_1 <- compute_did(data, condition_subgroup = 1, pscores = pscores, reg_adjustment = reg_adjust, xformula = xformula, est_method = est_method) # S=g, Q=1 vs. S=\infty, Q=0
 
   dr_ddd <- dr_att_inf_func_3$dr_att + dr_att_inf_func_2$dr_att - dr_att_inf_func_1$dr_att
   n <- data[, .N/2]

--- a/R/att_gt.R
+++ b/R/att_gt.R
@@ -147,7 +147,12 @@ att_gt <- function(did_preprocessed){
 
       # add post treatment dummy variable if period is equal to t + tfac
       cohort_data[, post := 0]
-      cohort_data[(period == tlist[max(t, pret) + tfac]), post := 1]
+
+      # Ypre is always the baseline, even in pre-treatment periods were baseline could be in later periods with respect to t.
+      pseudo_post = ifelse(post_treat == 1, tlist[max(t, pret) + tfac], tlist[t + tfac])
+      cohort_data[(period == pseudo_post), post := 1]
+
+      # cohort_data[(period == tlist[max(t, pret) + tfac]), post := 1]
       # Calculate the size of each subgroup in the 'subgroup' column
       subgroup_counts <- cohort_data[, .N/2, by = subgroup][order(-subgroup)]
 

--- a/R/print.ddd.R
+++ b/R/print.ddd.R
@@ -175,6 +175,6 @@ print.ddd <- function(x, alpha = NULL, ...) {
     cat("\n", paste0("Clustering Std. Errors by: ", x$argu$cluster))
   }
   cat("\n ==================================================================")
-  cat("\n See Ortiz-Villavicencio and Sant'Anna (2024) for details.")
+  cat("\n See Ortiz-Villavicencio and Sant'Anna (2025) for details.")
 
 }

--- a/tests/testthat/test-att_dr.R
+++ b/tests/testthat/test-att_dr.R
@@ -10,7 +10,7 @@ test_that("multiplication works", {
   ddd_analytical <- ddd(yname = "outcome", tname = "year", idname = "id", gname = "treat",
                  pname = "partition", xformla = ~x1 + x2,
                   data = test_panel, control_group = NULL, base_period = NULL, est_method = "dr", learners = NULL, n_folds = NULL,
-                  weightsname = NULL, boot = TRUE, nboot = NULL,
+                  weightsname = NULL, boot = TRUE, nboot = 1000,
                   inffunc = FALSE, skip_data_checks = FALSE)
 
   ddd_boostrap <- ddd(yname = "outcome", tname = "year", idname = "id", gname = "treat",

--- a/tests/testthat/test-preprocess.R
+++ b/tests/testthat/test-preprocess.R
@@ -91,7 +91,7 @@ test_that("Testing error handling in run_preprocess_2periods() function", {
   # Test 5: error for missing values in treatment variable "gname"
   expect_error(ddd(yname = "outcome", tname = "year", idname = "id", gname = "treat",
                    pname = "partition", xformla = ~x1 + x2,
-                   data = missing_values_treat_df, control_group = NULL, base_period = NULL, est_method = "dr", learners = NULL,
+                   data = missing_values_treat_df, control_group = "nevertreated", base_period = NULL, est_method = "dr", learners = NULL,
                    weightsname = NULL, boot = FALSE, nboot = NULL,
                    inffunc = FALSE, skip_data_checks = FALSE))
 
@@ -168,7 +168,7 @@ test_that("Testing error handling in run_preprocess_2periods() function", {
   # Test 16: More that 2 time periods
   expect_error(ddd(yname = "outcome", tname = "year", idname = "id", gname = "treat",
                    pname = "partition", xformla = ~x1 + x2,
-                   data = more_than_two_periods_df, control_group = NULL, base_period = NULL, est_method = "dr", learners = NULL,
+                   data = more_than_two_periods_df, control_group = "nevertreated", base_period = NULL, est_method = "dr", learners = NULL,
                    weightsname = NULL, boot = FALSE, nboot = NULL,
                    inffunc = FALSE, skip_data_checks = FALSE))
 


### PR DESCRIPTION
This PR resolves two issues in our triplediff workflow:
1. Pre-treatment sign reversal
	* Corrects an error in how Y_pre and Y_post are identified for pre-treatment periods, which previously caused estimated effects to flip sign.
2. Suppress spurious threading warnings
	* Silences unnecessary warnings from parglm and data.table when they auto-reduce the number of threads on small datasets.

Example of ATT(3,1)

Before:

![image](https://github.com/user-attachments/assets/2c4c49e4-8afe-46d1-89ae-4e8fcbc012a5)

Now:

![image](https://github.com/user-attachments/assets/a417c960-d902-47c6-a511-6258633579ae)
